### PR TITLE
Refactor Go Sprintf statements using Comby

### DIFF
--- a/rtsp/player.go
+++ b/rtsp/player.go
@@ -1,32 +1,32 @@
 package rtsp
 
 import (
+	"github.com/penggy/EasyGoLib/utils"
 	"sync"
 	"time"
-	"github.com/penggy/EasyGoLib/utils"
 )
 
 type Player struct {
 	*Session
-	Pusher *Pusher
-	cond   *sync.Cond
-	queue  []*RTPPack
-	queueLimit int
+	Pusher               *Pusher
+	cond                 *sync.Cond
+	queue                []*RTPPack
+	queueLimit           int
 	dropPacketWhenPaused bool
-	paused bool
+	paused               bool
 }
 
 func NewPlayer(session *Session, pusher *Pusher) (player *Player) {
 	queueLimit := utils.Conf().Section("rtsp").Key("player_queue_limit").MustInt(0)
 	dropPacketWhenPaused := utils.Conf().Section("rtsp").Key("drop_packet_when_paused").MustInt(0)
 	player = &Player{
-		Session: session,
-		Pusher:  pusher,
-		cond:    sync.NewCond(&sync.Mutex{}),
-		queue:   make([]*RTPPack, 0),
-		queueLimit: queueLimit,
+		Session:              session,
+		Pusher:               pusher,
+		cond:                 sync.NewCond(&sync.Mutex{}),
+		queue:                make([]*RTPPack, 0),
+		queueLimit:           queueLimit,
 		dropPacketWhenPaused: dropPacketWhenPaused != 0,
-		paused:  false,
+		paused:               false,
 	}
 	session.StopHandles = append(session.StopHandles, func() {
 		pusher.RemovePlayer(player)
@@ -50,7 +50,7 @@ func (player *Player) QueueRTP(pack *RTPPack) *Player {
 		player.queue = player.queue[1:]
 		if player.debugLogEnable {
 			len := len(player.queue)
-			logger.Printf("Player %s, QueueRTP, exceeds limit(%d), drop %d old packets, current queue.len=%d\n", player.String(), player.queueLimit, oldLen - len, len)
+			logger.Printf("Player %s, QueueRTP, exceeds limit(%d), drop %d old packets, current queue.len=%d\n", player.String(), player.queueLimit, oldLen-len, len)
 		}
 	}
 	player.cond.Signal()

--- a/rtsp/rtsp-client.go
+++ b/rtsp/rtsp-client.go
@@ -48,8 +48,8 @@ type RTSPClient struct {
 	OptionIntervalMillis int64
 	SDPRaw               string
 
-	debugLogEnable       bool
-	lastRtpSN            uint16
+	debugLogEnable bool
+	lastRtpSN      uint16
 
 	Agent    string
 	authLine string
@@ -427,8 +427,8 @@ func (client *RTSPClient) startStream() {
 				rtp := ParseRTP(pack.Buffer.Bytes())
 				if rtp != nil {
 					rtpSN := uint16(rtp.SequenceNumber)
-					if client.lastRtpSN != 0 && client.lastRtpSN + 1 != rtpSN {
-						client.logger.Printf("%s, %d packets lost, current SN=%d, last SN=%d\n", client.String(), rtpSN - client.lastRtpSN, rtpSN, client.lastRtpSN)
+					if client.lastRtpSN != 0 && client.lastRtpSN+1 != rtpSN {
+						client.logger.Printf("%s, %d packets lost, current SN=%d, last SN=%d\n", client.String(), rtpSN-client.lastRtpSN, rtpSN, client.lastRtpSN)
 					}
 					client.lastRtpSN = rtpSN
 				}


### PR DESCRIPTION
This campaign refactors Go code by replacing `fmt.Sprintf("%d", number)` statements with the equivalent but clearer `strconv.Itoa(number)`.

It uses [Comby](https://comby.dev) to do the replacement and then runs `gofmt` over the repositories.

Here is the action definition:

```json
{
  "scopeQuery": "lang:go fmt.Sprintf(\"%d\", fork:yes -repo:sourcegraph-testing/go",
  "steps": [
    {
      "type": "docker", "image": "comby/comby",
      "args": [ "-in-place", "fmt.Sprintf(\"%d\", :[v])", "strconv.Itoa(:[v])", ".go", "-matcher", ".go", "-d", "/work", "-exclude-dir", ".,vendor" ]
    },
    { "type": "docker", "image": "golang:1.14-alpine", "args": ["sh", "-c", "cd /work && go fmt ./..."] }
  ]
}
```